### PR TITLE
Enable scrolling in modal dialogs

### DIFF
--- a/_embed/templates/theme-global/stylesheet/modal.css
+++ b/_embed/templates/theme-global/stylesheet/modal.css
@@ -42,6 +42,7 @@
 
 	/* Scrolling behavior */
 	display:flow-root;
+	overflow-y: auto;
 
 	/* Display properties for visible dialog */
 	position:relative;


### PR DESCRIPTION
Hey, this is a cool project + I like it -- I have a couple of PRs to send for minor issues I've encountered though.

For this one, the setup doesn't work well on my machine because the modal dialogs on setup are too big to fit in the browser window sometimes. This patch enables scrolling of the content on modal dialogs when needed to make sure the user can find all the stuff.