### PR TITLE
use a minimalist+secure image for ffmpeg as a base

### DIFF
--- a/.docker/demo-dockerfile
+++ b/.docker/demo-dockerfile
@@ -16,12 +16,7 @@ COPY . .
 RUN go build -o emissary server.go
 
 # Start a new stage from scratch
-FROM debian:bookworm-slim
-
-# Install ffmpeg
-# This is required for audio/video transcoding
-RUN apt-get update -y
-RUN apt-get install -y ffmpeg
+FROM cgr.dev/chainguard/ffmpeg:latest
 
 WORKDIR /app
 

--- a/.docker/prod-dockerfile
+++ b/.docker/prod-dockerfile
@@ -26,12 +26,7 @@ RUN go build -o emissary server.go
 #################
 # -- Stage 2 -- #
 # Create the final environment with the compiled binary.
-FROM debian:bookworm-slim
-
-# Install ffmpeg
-# This is required for audio/video transcoding
-RUN apt-get update -y
-RUN apt-get install -y ffmpeg
+FROM cgr.dev/chainguard/ffmpeg:latest
 
 WORKDIR /app
 


### PR DESCRIPTION
As the image ran by the server only needs emissary + ffmpeg, we don't need the whole debian heavy base. And as ffmpeg is the more annoying to install because of its dependencies, it's better to go that way.

chainguard are well known to keep the images small and secure. I think they could be a good base. And we go from 800~MB -> 150MB.