### PR TITLE
Fixed typo in admin setup home page

### DIFF
--- a/_embed/setup/index.html
+++ b/_embed/setup/index.html
@@ -13,7 +13,7 @@
 			</div>
 	
 			<div class="margin-bottom">
-				This is the Emissary setup console, lets helps administrators
+				This is the Emissary setup console! It helps administrators
 				configure the domains that Emissary will serve, 
 				along with other file locations and settings.
 			</div>


### PR DESCRIPTION
I was testing emissary on my local dev environment and noticed this typo when I started the admin server. I decided to upstream a correction while I was looking at the code. 

Good job on this project BTW and I look forward into delving into more of it on my free time. :clinking_glasses: 